### PR TITLE
Fixed uneven padding and odd behavior of image on clicking 

### DIFF
--- a/src/styles/layout/_section.scss
+++ b/src/styles/layout/_section.scss
@@ -38,10 +38,11 @@
                 }
                 &__Content{
                     display: grid;
+                    place-items: center;
                     grid-template-rows: repeat(3,1fr);
                     grid-template-columns: repeat(3,1fr);
                     height:100%;
-                    padding: 1rem 0 0 1.5rem;
+                    padding: 1rem 1rem;
 
                     
                     &-row{


### PR DESCRIPTION
### Fixed uneven padding and the odd behavior of image when a user clicks on it was because of this padding issue as we were adding .4 rem padding on both sides and because of un even padding on both sides our images had to shift right bottom a little when ever user clicked on image but now it's resolved

![Icovia-Page-1-PreviewContainerHightlitedFixed](https://user-images.githubusercontent.com/37766405/136145114-8de9e8e1-700e-4a1b-8c2a-59cffeaeef91.png)
.
